### PR TITLE
VM-side forwarding implementation

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -383,7 +383,6 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.20.0"
-source = "git+https://github.com/mmtk/mmtk-core.git#29d482cf7b470ad3b09f88c6993babd6f695d832"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -417,7 +416,6 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.20.0"
-source = "git+https://github.com/mmtk/mmtk-core.git#29d482cf7b470ad3b09f88c6993babd6f695d832"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -33,7 +33,7 @@ atomic_refcell = "0.1.9"
 probe = "0.5"
 
 [dependencies.mmtk]
-features = ["is_mmtk_object", "object_pinning"]
+features = ["is_mmtk_object", "object_pinning", "vm_forwarding"]
 
 # Uncomment one of the following lines to choose where to find mmtk-core.
 #git = "https://github.com/mmtk/mmtk-core.git"  # Use mmtk-core from the official repository.

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -36,8 +36,8 @@ probe = "0.5"
 features = ["is_mmtk_object", "object_pinning"]
 
 # Uncomment one of the following lines to choose where to find mmtk-core.
-git = "https://github.com/mmtk/mmtk-core.git"  # Use mmtk-core from the official repository.
-#path = "../../mmtk-core"  # Use mmtk-core from a local repository.
+#git = "https://github.com/mmtk/mmtk-core.git"  # Use mmtk-core from the official repository.
+path = "../../mmtk-core"  # Use mmtk-core from a local repository.
 
 [features]
 default = []

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -37,6 +37,8 @@ impl ObjectModel<Ruby> for VMObjectModel {
 
     const NEED_VO_BITS_DURING_TRACING: bool = true;
 
+    const VM_IMPLEMENTED_FORWARDING: bool = true;
+
     fn copy(
         from: ObjectReference,
         semantics: CopySemantics,
@@ -136,5 +138,26 @@ impl ObjectModel<Ruby> for VMObjectModel {
 
     fn dump_object(_object: ObjectReference) {
         todo!()
+    }
+
+    fn attempt_to_forward(object: ObjectReference) -> Result<usize, ()> {
+        
+    }
+
+    fn write_forwarding_state_and_forwarding_pointer(
+            object: ObjectReference,
+            new_object: ObjectReference,
+        ) {
+        
+    }
+
+    fn revert_forwarding_state(object: ObjectReference, vm_data: usize) {
+        
+    }
+
+    fn spin_and_get_forwarded_object(
+            object: ObjectReference,
+        ) -> ObjectReference {
+        
     }
 }

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -141,23 +141,22 @@ impl ObjectModel<Ruby> for VMObjectModel {
     }
 
     fn attempt_to_forward(object: ObjectReference) -> Result<usize, ()> {
-        
+        RubyObjectAccess::from_objref(object).attempt_to_forward()
     }
 
     fn write_forwarding_state_and_forwarding_pointer(
-            object: ObjectReference,
-            new_object: ObjectReference,
-        ) {
-        
+        object: ObjectReference,
+        new_object: ObjectReference,
+    ) {
+        RubyObjectAccess::from_objref(object)
+            .write_forwarding_state_and_forwarding_pointer(new_object)
     }
 
     fn revert_forwarding_state(object: ObjectReference, vm_data: usize) {
-        
+        RubyObjectAccess::from_objref(object).revert_forwarding_state(vm_data)
     }
 
-    fn spin_and_get_forwarded_object(
-            object: ObjectReference,
-        ) -> ObjectReference {
-        
+    fn spin_and_get_forwarded_object(object: ObjectReference) -> ObjectReference {
+        RubyObjectAccess::from_objref(object).spin_and_get_forwarded_object()
     }
 }

--- a/mmtk/src/object_model.rs
+++ b/mmtk/src/object_model.rs
@@ -2,7 +2,6 @@ use std::ptr::copy_nonoverlapping;
 
 use crate::abi::{RubyObjectAccess, MIN_OBJ_ALIGN, OBJREF_OFFSET};
 use crate::{abi, Ruby};
-use mmtk::util::constants::BITS_IN_BYTE;
 use mmtk::util::copy::{CopySemantics, GCWorkerCopyContext};
 use mmtk::util::{Address, ObjectReference};
 use mmtk::vm::*;
@@ -18,15 +17,18 @@ impl ObjectModel<Ruby> for VMObjectModel {
 
     const GLOBAL_LOG_BIT_SPEC: VMGlobalLogBitSpec = VMGlobalLogBitSpec::side_first();
 
-    // We overwrite the prepended word which were used to hold object sizes.
+    /// Not used.  We implement forwarding in the VM binding, and put the forwarding pointer at the
+    /// same offset as `RMoved::destination` in C.
     const LOCAL_FORWARDING_POINTER_SPEC: VMLocalForwardingPointerSpec =
-        VMLocalForwardingPointerSpec::in_header(-((OBJREF_OFFSET * BITS_IN_BYTE) as isize));
+        VMLocalForwardingPointerSpec::in_header(0);
 
+    /// Not used.  We implement forwarding in the VM binding, and represent forwarding states with
+    /// `T_MOVED`. See `abi.rs`.
     const LOCAL_FORWARDING_BITS_SPEC: VMLocalForwardingBitsSpec =
-        VMLocalForwardingBitsSpec::side_first();
+        VMLocalForwardingBitsSpec::in_header(0);
 
     const LOCAL_MARK_BIT_SPEC: VMLocalMarkBitSpec =
-        VMLocalMarkBitSpec::side_after(Self::LOCAL_FORWARDING_BITS_SPEC.as_spec());
+        VMLocalMarkBitSpec::side_first();
 
     const LOCAL_PINNING_BIT_SPEC: VMLocalPinningBitSpec =
         VMLocalPinningBitSpec::side_after(Self::LOCAL_MARK_BIT_SPEC.as_spec());


### PR DESCRIPTION
This PR makes use of the change in mmtk-core (https://github.com/mmtk/mmtk-core/pull/975) so that we can implement forwarding states using `T_MOVED` instead of relying on on-the-side forwarding bits.