### PR TITLE
Update the ruby repo revision

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -375,8 +375,8 @@ dependencies = [
 
 [[package]]
 name = "mmtk"
-version = "0.22.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=b66fa351c6e37e4a0672070aab5cd5864d150890#b66fa351c6e37e4a0672070aab5cd5864d150890"
+version = "0.22.1"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=42754a5f23fdb513039d7f07e52014ded42c98bf#42754a5f23fdb513039d7f07e52014ded42c98bf"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -410,8 +410,8 @@ dependencies = [
 
 [[package]]
 name = "mmtk-macros"
-version = "0.22.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=b66fa351c6e37e4a0672070aab5cd5864d150890#b66fa351c6e37e4a0672070aab5cd5864d150890"
+version = "0.22.1"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=42754a5f23fdb513039d7f07e52014ded42c98bf#42754a5f23fdb513039d7f07e52014ded42c98bf"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # Metadata for the Ruby repository
 [package.metadata.ci-repos.ruby]
 repo = "mmtk/ruby" # This is used by actions/checkout, so the format is "owner/repo", not URL.
-rev = "1f4c40d550137827b76fcf66cc6f217681927dba"
+rev = "68a6bbf8b5dc4faa06199337af28acf5a2511614"
 
 [lib]
 name = "mmtk_ruby"
@@ -37,7 +37,7 @@ features = ["is_mmtk_object", "object_pinning"]
 
 # Uncomment the following lines to use mmtk-core from the official repository.
 git = "https://github.com/mmtk/mmtk-core.git"
-rev = "b66fa351c6e37e4a0672070aab5cd5864d150890"
+rev = "42754a5f23fdb513039d7f07e52014ded42c98bf"
 
 # Uncomment the following line to use mmtk-core from a local repository.
 #path = "../../mmtk-core"


### PR DESCRIPTION
A commit in the `ruby` repo now treats iseq as PPP again, and fixes a random failure in CI.

Fixes: https://github.com/mmtk/mmtk-ruby/issues/49