### PR TITLE
(Experimental) Join GC threads on the binding side.

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -376,7 +376,6 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.22.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=b66fa351c6e37e4a0672070aab5cd5864d150890#b66fa351c6e37e4a0672070aab5cd5864d150890"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -411,7 +410,6 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.22.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=b66fa351c6e37e4a0672070aab5cd5864d150890#b66fa351c6e37e4a0672070aab5cd5864d150890"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "mmtk"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "mmtk-macros"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -376,7 +376,6 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.22.1"
-source = "git+https://github.com/wks/mmtk-core.git?rev=7cb0b2c12be341c084e03f2cd943fad8ac088f83#7cb0b2c12be341c084e03f2cd943fad8ac088f83"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -411,7 +410,6 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.22.1"
-source = "git+https://github.com/wks/mmtk-core.git?rev=7cb0b2c12be341c084e03f2cd943fad8ac088f83#7cb0b2c12be341c084e03f2cd943fad8ac088f83"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -376,6 +376,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.22.1"
+source = "git+https://github.com/wks/mmtk-core.git?rev=7cb0b2c12be341c084e03f2cd943fad8ac088f83#7cb0b2c12be341c084e03f2cd943fad8ac088f83"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -410,6 +411,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.22.1"
+source = "git+https://github.com/wks/mmtk-core.git?rev=7cb0b2c12be341c084e03f2cd943fad8ac088f83#7cb0b2c12be341c084e03f2cd943fad8ac088f83"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -36,11 +36,11 @@ probe = "0.5"
 features = ["is_mmtk_object", "object_pinning"]
 
 # Uncomment the following lines to use mmtk-core from the official repository.
-git = "https://github.com/mmtk/mmtk-core.git"
-rev = "b66fa351c6e37e4a0672070aab5cd5864d150890"
+#git = "https://github.com/mmtk/mmtk-core.git"
+#rev = "b66fa351c6e37e4a0672070aab5cd5864d150890"
 
 # Uncomment the following line to use mmtk-core from a local repository.
-#path = "../../mmtk-core"
+path = "../../mmtk-core"
 
 [features]
 default = []

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -36,11 +36,11 @@ probe = "0.5"
 features = ["is_mmtk_object", "object_pinning"]
 
 # Uncomment the following lines to use mmtk-core from the official repository.
-git = "https://github.com/wks/mmtk-core.git"
-rev = "7cb0b2c12be341c084e03f2cd943fad8ac088f83"
+#git = "https://github.com/wks/mmtk-core.git"
+#rev = "7cb0b2c12be341c084e03f2cd943fad8ac088f83"
 
 # Uncomment the following line to use mmtk-core from a local repository.
-#path = "../../mmtk-core"
+path = "../../mmtk-core"
 
 [features]
 default = []

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -36,11 +36,11 @@ probe = "0.5"
 features = ["is_mmtk_object", "object_pinning"]
 
 # Uncomment the following lines to use mmtk-core from the official repository.
-#git = "https://github.com/mmtk/mmtk-core.git"
-#rev = "42754a5f23fdb513039d7f07e52014ded42c98bf"
+git = "https://github.com/wks/mmtk-core.git"
+rev = "7cb0b2c12be341c084e03f2cd943fad8ac088f83"
 
 # Uncomment the following line to use mmtk-core from a local repository.
-path = "../../mmtk-core"
+#path = "../../mmtk-core"
 
 [features]
 default = []

--- a/mmtk/src/abi.rs
+++ b/mmtk/src/abi.rs
@@ -1,13 +1,12 @@
 use crate::api::RubyMutator;
 use crate::{upcalls, Ruby};
-use mmtk::scheduler::{GCController, GCWorker};
+use mmtk::scheduler::GCWorker;
 use mmtk::util::{Address, ObjectReference, VMMutatorThread, VMWorkerThread};
 
 // For the C binding
 pub const OBJREF_OFFSET: usize = 8;
 pub const MIN_OBJ_ALIGN: usize = 8; // Even on 32-bit machine.  A Ruby object is at least 40 bytes large.
 
-pub const GC_THREAD_KIND_CONTROLLER: libc::c_int = 0;
 pub const GC_THREAD_KIND_WORKER: libc::c_int = 1;
 
 const HAS_MOVED_GIVTBL: usize = 1 << 63;
@@ -244,10 +243,6 @@ impl GCThreadTLS {
         }
     }
 
-    pub fn for_controller(gc_context: *mut GCController<Ruby>) -> Self {
-        Self::new(GC_THREAD_KIND_CONTROLLER, gc_context as *mut libc::c_void)
-    }
-
     pub fn for_worker(gc_context: *mut GCWorker<Ruby>) -> Self {
         Self::new(GC_THREAD_KIND_WORKER, gc_context as *mut libc::c_void)
     }
@@ -266,7 +261,7 @@ impl GCThreadTLS {
         let result = &mut *ptr;
         debug_assert!({
             let kind = result.kind;
-            kind == GC_THREAD_KIND_CONTROLLER || kind == GC_THREAD_KIND_WORKER
+            kind == GC_THREAD_KIND_WORKER
         });
         result
     }

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -155,8 +155,13 @@ pub extern "C" fn mmtk_initialize_collection(tls: VMThread) {
 }
 
 #[no_mangle]
-pub extern "C" fn mmtk_uninitialize_collection() {
-    memory_manager::uninitialize_collection(mmtk())
+pub extern "C" fn mmtk_prepare_to_fork() {
+    mmtk().prepare_to_fork();
+}
+
+#[no_mangle]
+pub extern "C" fn mmtk_after_fork(tls: VMThread) {
+    mmtk().after_fork(tls);
 }
 
 #[no_mangle]

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -157,6 +157,7 @@ pub extern "C" fn mmtk_initialize_collection(tls: VMThread) {
 #[no_mangle]
 pub extern "C" fn mmtk_prepare_to_fork() {
     mmtk().prepare_to_fork();
+    binding().join_all_gc_threads();
 }
 
 #[no_mangle]

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -155,6 +155,11 @@ pub extern "C" fn mmtk_initialize_collection(tls: VMThread) {
 }
 
 #[no_mangle]
+pub extern "C" fn mmtk_uninitialize_collection() {
+    memory_manager::uninitialize_collection(mmtk())
+}
+
+#[no_mangle]
 pub extern "C" fn mmtk_enable_collection() {
     memory_manager::enable_collection(mmtk())
 }

--- a/mmtk/src/collection.rs
+++ b/mmtk/src/collection.rs
@@ -37,7 +37,11 @@ impl Collection<Ruby> for VMCollection {
                 thread::Builder::new()
                     .name("MMTk Worker Thread".to_string())
                     .spawn(move || {
-                        debug!("Hello! This is MMTk Worker Thread running!");
+                        let ordinal = worker.ordinal;
+                        debug!(
+                            "Hello! This is MMTk Worker Thread running! ordinal: {}",
+                            ordinal
+                        );
                         crate::register_gc_thread(thread::current().id());
                         let ptr_worker = &mut *worker as *mut GCWorker<Ruby>;
                         let gc_thread_tls =
@@ -46,12 +50,12 @@ impl Collection<Ruby> for VMCollection {
                         memory_manager::start_worker(
                             mmtk(),
                             GCThreadTLS::to_vwt(gc_thread_tls),
-                            &mut worker,
+                            worker,
                         );
-
-                        // Currently all MMTk worker threads should run forever.
-                        // This is an unlikely event, but we log it anyway.
-                        warn!("An MMTk Worker Thread is quitting!");
+                        debug!(
+                            "An MMTk Worker Thread is quitting. Good bye! ordinal: {}",
+                            ordinal
+                        );
                         crate::unregister_gc_thread(thread::current().id());
                     })
                     .unwrap();


### PR DESCRIPTION
This is an alternative to https://github.com/mmtk/mmtk-ruby/pull/53.  This PR lets mmtk-ruby join the GC worker threads.