### PR TITLE
StickyImmix support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: true
       matrix:
         debug-level: ["debug", "release"]
-        plan: ["MarkSweep", "Immix"]
+        plan: ["MarkSweep", "Immix", "StickyImmix"]
     env:
       DEBUG_LEVEL: ${{ matrix.debug-level }}
       CHOSEN_PLAN: ${{ matrix.plan }}

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys",
 ]
@@ -688,9 +688,9 @@ checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 
 [[package]]
 name = "strum_macros"
-version = "0.26.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7993a8e3a9e88a00351486baae9522c91b123a088f76469e5bd5cc17198ea87"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # Metadata for the Ruby repository
 [package.metadata.ci-repos.ruby]
 repo = "mmtk/ruby" # This is used by actions/checkout, so the format is "owner/repo", not URL.
-rev = "4d7e5e50760cfe99c4013a3d841379f0bc24283f"
+rev = "16129160eedfac4396617a27141c1a2644f7d36a"
 
 [lib]
 name = "mmtk_ruby"
@@ -33,7 +33,7 @@ atomic_refcell = "0.1.9"
 probe = "0.5"
 
 [dependencies.mmtk]
-features = ["is_mmtk_object", "object_pinning"]
+features = ["is_mmtk_object", "object_pinning", "sticky_immix_non_moving_nursery"]
 
 # Uncomment the following lines to use mmtk-core from the official repository.
 git = "https://github.com/mmtk/mmtk-core.git"

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -12,6 +12,7 @@ use crate::binding;
 use crate::binding::RubyBinding;
 use crate::mmtk;
 use crate::Ruby;
+use crate::RubySlot;
 use crate::BINDING_FAST;
 use mmtk::memory_manager;
 use mmtk::memory_manager::mmtk_init;
@@ -324,4 +325,29 @@ pub extern "C" fn mmtk_unpin_object(object: ObjectReference) -> bool {
 #[no_mangle]
 pub extern "C" fn mmtk_is_pinned(object: ObjectReference) -> bool {
     mmtk::memory_manager::is_pinned::<Ruby>(object)
+}
+
+#[no_mangle]
+pub extern "C" fn mmtk_register_wb_unprotected_object(object: ObjectReference) {
+    crate::binding().register_wb_unprotected_object(object)
+}
+
+#[no_mangle]
+pub extern "C" fn mmtk_is_object_wb_unprotected(object: ObjectReference) -> bool {
+    crate::binding().is_object_wb_unprotected(object)
+}
+
+#[no_mangle]
+pub extern "C" fn mmtk_object_reference_write_post(
+    mutator: *mut RubyMutator,
+    object: ObjectReference,
+) {
+    let ignored_slot = RubySlot::from_address(Address::ZERO);
+    let ignored_target = ObjectReference::from_raw_address(Address::ZERO);
+    mmtk::memory_manager::object_reference_write_post(
+        unsafe { &mut *mutator },
+        object,
+        ignored_slot,
+        ignored_target,
+    )
 }


### PR DESCRIPTION
This commit adds support for the StickyImmix plan.  It includes handling of write barriers and WB-unprotected objects.  The CI will also test StickyImmix alongside Immix and MarkSweep.
