### PR TITLE
Fix option detection

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -432,7 +432,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.25.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=a9b619a4ee18a4f83209f930f8c48a3b63ee478c#a9b619a4ee18a4f83209f930f8c48a3b63ee478c"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=401803ce44d851c19e4d04f152b494095f9b71e6#401803ce44d851c19e4d04f152b494095f9b71e6"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -467,7 +467,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.25.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=a9b619a4ee18a4f83209f930f8c48a3b63ee478c#a9b619a4ee18a4f83209f930f8c48a3b63ee478c"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=401803ce44d851c19e4d04f152b494095f9b71e6#401803ce44d851c19e4d04f152b494095f9b71e6"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # Metadata for the Ruby repository
 [package.metadata.ci-repos.ruby]
 repo = "mmtk/ruby" # This is used by actions/checkout, so the format is "owner/repo", not URL.
-rev = "16129160eedfac4396617a27141c1a2644f7d36a"
+rev = "16b93e42494b80dca676d7a47cb2400f6773c0fd"
 
 [lib]
 name = "mmtk_ruby"
@@ -37,7 +37,7 @@ features = ["is_mmtk_object", "object_pinning", "sticky_immix_non_moving_nursery
 
 # Uncomment the following lines to use mmtk-core from the official repository.
 git = "https://github.com/mmtk/mmtk-core.git"
-rev = "a9b619a4ee18a4f83209f930f8c48a3b63ee478c"
+rev = "401803ce44d851c19e4d04f152b494095f9b71e6"
 
 # Uncomment the following line to use mmtk-core from a local repository.
 # path = "../../mmtk-core"

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -83,6 +83,27 @@ pub extern "C" fn mmtk_builder_set_plan(builder: *mut MMTKBuilder, plan_name: *c
     builder.options.plan.set(plan_selector);
 }
 
+/// Query if the selected plan is MarkSweep.
+#[no_mangle]
+pub extern "C" fn mmtk_builder_is_mark_sweep(builder: *mut MMTKBuilder) -> bool {
+    let builder = unsafe { &mut *builder };
+    matches!(*builder.options.plan, PlanSelector::MarkSweep)
+}
+
+/// Query if the selected plan is Immix.
+#[no_mangle]
+pub extern "C" fn mmtk_builder_is_immix(builder: *mut MMTKBuilder) -> bool {
+    let builder = unsafe { &mut *builder };
+    matches!(*builder.options.plan, PlanSelector::Immix)
+}
+
+/// Query if the selected plan is StickyImmix.
+#[no_mangle]
+pub extern "C" fn mmtk_builder_is_sticky_immix(builder: *mut MMTKBuilder) -> bool {
+    let builder = unsafe { &mut *builder };
+    matches!(*builder.options.plan, PlanSelector::StickyImmix)
+}
+
 /// Build an MMTk instance.
 ///
 /// -   `builder` is the pointer to the `MMTKBuilder` instance created by the


### PR DESCRIPTION
Added API functions so that the C part of the VM can query the plan selector in the MMTKBuilder.  This is needed by the corresponding commit in the `ruby` repo.

Also bumped the revision of the mmtk-core repo.