### PR TITLE
Do not use the finalization framework in mmtk-core

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.25.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=401803ce44d851c19e4d04f152b494095f9b71e6#401803ce44d851c19e4d04f152b494095f9b71e6"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=1095465e465dfd777cf4f6fc6ba01964be1d4604#1095465e465dfd777cf4f6fc6ba01964be1d4604"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.25.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=401803ce44d851c19e4d04f152b494095f9b71e6#401803ce44d851c19e4d04f152b494095f9b71e6"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=1095465e465dfd777cf4f6fc6ba01964be1d4604#1095465e465dfd777cf4f6fc6ba01964be1d4604"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -37,7 +37,7 @@ features = ["is_mmtk_object", "object_pinning", "sticky_immix_non_moving_nursery
 
 # Uncomment the following lines to use mmtk-core from the official repository.
 git = "https://github.com/mmtk/mmtk-core.git"
-rev = "401803ce44d851c19e4d04f152b494095f9b71e6"
+rev = "1095465e465dfd777cf4f6fc6ba01964be1d4604"
 
 # Uncomment the following line to use mmtk-core from a local repository.
 # path = "../../mmtk-core"

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -36,7 +36,9 @@ pub type RubyMutator = Mutator<Ruby>;
 /// This instance shall be consumed by `mmtk_init_binding`.
 #[no_mangle]
 pub extern "C" fn mmtk_builder_default() -> *mut MMTKBuilder {
-    let builder = MMTKBuilder::new_no_env_vars();
+    let mut builder = MMTKBuilder::new_no_env_vars();
+    // We don't use the Java-style finalization framework in mmtk-core.
+    builder.options.no_finalizer.set(true);
     Box::into_raw(Box::new(builder))
 }
 


### PR DESCRIPTION
The `FinalizableProcessor` in mmtk-core was designed for Java.  We do not use it for Ruby.  Instead we implement our own `WeakProcessor`. Disabling the finalization mechanism in mmtk-core will eliminate one unused work packet in every GC.