### PR TITLE
Process weak tables in small chunks in parallel

### DIFF
--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # Metadata for the Ruby repository
 [package.metadata.ci-repos.ruby]
 repo = "mmtk/ruby" # This is used by actions/checkout, so the format is "owner/repo", not URL.
-rev = "e3fe53d198c6d1aea79ee4a90369b1f46a2c5a44"
+rev = "0f475fdfee76247c516464aac04022338a5ed824"
 
 [lib]
 name = "mmtk_ruby"

--- a/mmtk/src/abi.rs
+++ b/mmtk/src/abi.rs
@@ -389,8 +389,14 @@ pub struct RubyUpcalls {
         entries_bound: *mut libc::size_t,
         bins_num: *mut libc::size_t,
     ),
-    pub st_update_entries_range:
-        extern "C" fn(table: *mut st_table, begin: libc::size_t, end: libc::size_t),
+    pub st_update_entries_range: extern "C" fn(
+        table: *mut st_table,
+        begin: libc::size_t,
+        end: libc::size_t,
+        weak_keys: bool,
+        weak_records: bool,
+        forward: bool,
+    ),
     pub st_update_bins_range:
         extern "C" fn(table: *mut st_table, begin: libc::size_t, end: libc::size_t),
 }

--- a/mmtk/src/abi.rs
+++ b/mmtk/src/abi.rs
@@ -15,6 +15,10 @@ const HIDDEN_SIZE_MASK: usize = 0x0000FFFFFFFFFFFF;
 // Should keep in sync with C code.
 const RUBY_FL_EXIVAR: usize = 1 << 10;
 
+// An opaque type for the C counterpart.
+#[allow(non_camel_case_types)]
+pub struct st_table;
+
 /// Provide convenient methods for accessing Ruby objects.
 /// TODO: Wrap C functions in `RubyUpcalls` as Rust-friendly methods.
 pub struct RubyObjectAccess {
@@ -364,15 +368,31 @@ pub struct RubyUpcalls {
     pub call_gc_mark_children: extern "C" fn(object: ObjectReference),
     pub call_obj_free: extern "C" fn(object: ObjectReference),
     pub cleanup_generic_iv_tbl: extern "C" fn(),
+    pub get_original_givtbl: extern "C" fn(object: ObjectReference) -> *mut libc::c_void,
+    pub move_givtbl: extern "C" fn(old_objref: ObjectReference, new_objref: ObjectReference),
+    pub vm_live_bytes: extern "C" fn() -> usize,
     pub update_frozen_strings_table: extern "C" fn(),
     pub update_finalizer_table: extern "C" fn(),
     pub update_obj_id_tables: extern "C" fn(),
     pub update_global_symbols_table: extern "C" fn(),
     pub update_overloaded_cme_table: extern "C" fn(),
     pub update_ci_table: extern "C" fn(),
-    pub get_original_givtbl: extern "C" fn(object: ObjectReference) -> *mut libc::c_void,
-    pub move_givtbl: extern "C" fn(old_objref: ObjectReference, new_objref: ObjectReference),
-    pub vm_live_bytes: extern "C" fn() -> usize,
+    pub get_frozen_strings_table: extern "C" fn() -> *mut st_table,
+    pub get_finalizer_table: extern "C" fn() -> *mut st_table,
+    pub get_obj_id_tables: extern "C" fn() -> *mut st_table,
+    pub get_global_symbols_table: extern "C" fn() -> *mut st_table,
+    pub get_overloaded_cme_table: extern "C" fn() -> *mut st_table,
+    pub get_ci_table: extern "C" fn() -> *mut st_table,
+    pub st_get_size_info: extern "C" fn(
+        table: *const st_table,
+        entries_start: *mut libc::size_t,
+        entries_bound: *mut libc::size_t,
+        bins_num: *mut libc::size_t,
+    ),
+    pub st_update_entries_range:
+        extern "C" fn(table: *mut st_table, begin: libc::size_t, end: libc::size_t),
+    pub st_update_bins_range:
+        extern "C" fn(table: *mut st_table, begin: libc::size_t, end: libc::size_t),
 }
 
 unsafe impl Sync for RubyUpcalls {}

--- a/mmtk/src/utils.rs
+++ b/mmtk/src/utils.rs
@@ -55,6 +55,8 @@ pub struct AfterAll {
     packets: AtomicRefCell<Vec<Box<dyn GCWork<Ruby>>>>,
 }
 
+unsafe impl Sync for AfterAll {}
+
 impl AfterAll {
     pub fn new(stage: WorkBucketStage) -> Self {
         Self {


### PR DESCRIPTION
This will split the processing of large global weak tables, such as the frozen string table and the global symbol table, into smaller chunks so that they can be processed in parallel.