### PR TITLE
Fix ActivePlan::number_of_mutators

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -431,7 +431,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.26.0"
-source = "git+https://github.com/wks/mmtk-core.git?rev=b4ed92905fb1218692170374cb6ee5b23b239a5e#b4ed92905fb1218692170374cb6ee5b23b239a5e"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=f78523616ea4989148f60c0943bd2c6cae364339#f78523616ea4989148f60c0943bd2c6cae364339"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -467,7 +467,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.26.0"
-source = "git+https://github.com/wks/mmtk-core.git?rev=b4ed92905fb1218692170374cb6ee5b23b239a5e#b4ed92905fb1218692170374cb6ee5b23b239a5e"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=f78523616ea4989148f60c0943bd2c6cae364339#f78523616ea4989148f60c0943bd2c6cae364339"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -431,7 +431,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.26.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=f9b85bca5b1ae530854e09d553f3020edde46cdb#f9b85bca5b1ae530854e09d553f3020edde46cdb"
+source = "git+https://github.com/wks/mmtk-core.git?rev=b4ed92905fb1218692170374cb6ee5b23b239a5e#b4ed92905fb1218692170374cb6ee5b23b239a5e"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -467,7 +467,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.26.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=f9b85bca5b1ae530854e09d553f3020edde46cdb#f9b85bca5b1ae530854e09d553f3020edde46cdb"
+source = "git+https://github.com/wks/mmtk-core.git?rev=b4ed92905fb1218692170374cb6ee5b23b239a5e#b4ed92905fb1218692170374cb6ee5b23b239a5e"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -36,8 +36,8 @@ probe = "0.5"
 features = ["is_mmtk_object", "object_pinning", "sticky_immix_non_moving_nursery"]
 
 # Uncomment the following lines to use mmtk-core from the official repository.
-git = "https://github.com/wks/mmtk-core.git"
-rev = "b4ed92905fb1218692170374cb6ee5b23b239a5e"
+git = "https://github.com/mmtk/mmtk-core.git"
+rev = "f78523616ea4989148f60c0943bd2c6cae364339"
 
 # Uncomment the following line to use mmtk-core from a local repository.
 # path = "../../mmtk-core"

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # Metadata for the Ruby repository
 [package.metadata.ci-repos.ruby]
 repo = "mmtk/ruby" # This is used by actions/checkout, so the format is "owner/repo", not URL.
-rev = "1d3f79843ef8dafa90664b18a24d4b337a4e5117"
+rev = "8082532b9f720a1e7508ac32641dcfbbf51dd518"
 
 [lib]
 name = "mmtk_ruby"
@@ -36,8 +36,8 @@ probe = "0.5"
 features = ["is_mmtk_object", "object_pinning", "sticky_immix_non_moving_nursery"]
 
 # Uncomment the following lines to use mmtk-core from the official repository.
-git = "https://github.com/mmtk/mmtk-core.git"
-rev = "f9b85bca5b1ae530854e09d553f3020edde46cdb"
+git = "https://github.com/wks/mmtk-core.git"
+rev = "b4ed92905fb1218692170374cb6ee5b23b239a5e"
 
 # Uncomment the following line to use mmtk-core from a local repository.
 # path = "../../mmtk-core"


### PR DESCRIPTION
Updated the `ruby` repo revision to fix a bug where the number of mutators returned from `ActivePlan::number_of_mutators` does not match the number of mutators returned from `ActivePlan::mutators`.

Also updated the `mmtk-core` repo revision.  More assertions are added so that such bugs can be detected earlier.

mmtk-core PR: https://github.com/mmtk/mmtk-core/pull/1182
ruby PR: https://github.com/mmtk/ruby/pull/84

Fixes: https://github.com/mmtk/mmtk-ruby/issues/84