### PR TITLE
Ruby: Cherry-pick #80

### DIFF
--- a/.github/scripts/ci-test-all.sh
+++ b/.github/scripts/ci-test-all.sh
@@ -13,7 +13,10 @@ case $DEBUG_LEVEL in
         ;;
     release)
         TEST_CASES=$(cat $BINDING_PATH/ruby-test-cases.txt | grep -v '#' | ruby -ne 'puts "../#{$_}"' | xargs)
-        make test-all TESTS="$TEST_CASES" RUN_OPTS="--mmtk-plan=$CHOSEN_PLAN" TESTOPTS="-v -j${CI_JOBS}"
+        make test-all \
+             TESTS="$TEST_CASES" \
+             RUN_OPTS="--mmtk-plan=$CHOSEN_PLAN" \
+             TESTOPTS="-v --excludes-dir=../test/.excludes-mmtk -j${CI_JOBS}"
         ;;
     vanilla)
         # Temporarily disable test-all for the vanilla build.  Many TestGc test cases fail.

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # Metadata for the Ruby repository
 [package.metadata.ci-repos.ruby]
 repo = "mmtk/ruby" # This is used by actions/checkout, so the format is "owner/repo", not URL.
-rev = "a55df63fcc186880f2262ab7e54b442f2637ff2b"
+rev = "8c5bd19b7a73c5156c4e2b9ee25cbf89c66816b8"
 
 [lib]
 name = "mmtk_ruby"


### PR DESCRIPTION
The Ruby repository cherry-picked https://github.com/mmtk/ruby/pull/80
onto the dev/mmtk-overrides-default branch which will follow the
official master branch.  It added a CI scripts and excluded some tests
using Ruby scripts in the `.excludes-mmtk/` directory.

We add an option to `make test-all` to take the `.excludes-mmtk`
directory into consideration.

With this change, it should be, in theory, possible to selectively run
tests runnable for MMTk without using the whitelist
`ruby-test-cases.txt` in this repo.  However, some test cases still
crashes due to bugs in the binding.  We'll still use the whitelist for
running binding tests for the mmtk-core repo, until we fix those crashes
so that `make test-all` can finish safely with MMTk enabled.

Related PR: https://github.com/mmtk/ruby/pull/90