### PR TITLE
Expose an API for heap traversal.

### DIFF
--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # Metadata for the Ruby repository
 [package.metadata.ci-repos.ruby]
 repo = "mmtk/ruby" # This is used by actions/checkout, so the format is "owner/repo", not URL.
-rev = "8c5bd19b7a73c5156c4e2b9ee25cbf89c66816b8"
+rev = "da5e57a3cf1a5969a6d5b05cf371f613d21f42f7"
 
 [lib]
 name = "mmtk_ruby"

--- a/mmtk/src/api.rs
+++ b/mmtk/src/api.rs
@@ -374,3 +374,15 @@ pub extern "C" fn mmtk_object_reference_write_post(
         ignored_target,
     )
 }
+
+/// Enumerate objects.  This function will call `callback(object, data)` for each object. It has
+/// undefined behavior if allocation or GC happens while this function is running.
+#[no_mangle]
+pub extern "C" fn mmtk_enumerate_objects(
+    callback: extern "C" fn(ObjectReference, *mut libc::c_void),
+    data: *mut libc::c_void,
+) {
+    crate::mmtk().enumerate_objects(|object| {
+        callback(object, data);
+    })
+}

--- a/ruby-test-cases.txt
+++ b/ruby-test-cases.txt
@@ -53,7 +53,7 @@ test/ruby/test_integer.rb
 test/ruby/test_io_buffer.rb
 test/ruby/test_io_m17n.rb
 # test/ruby/test_io.rb                  XXXXX leaks?
-# test/ruby/test_iseq.rb                XXXXX failures
+test/ruby/test_iseq.rb
 test/ruby/test_iterator.rb
 test/ruby/test_key_error.rb
 test/ruby/test_keyword.rb
@@ -75,8 +75,8 @@ test/ruby/test_nomethod_error.rb
 test/ruby/test_not.rb
 test/ruby/test_numeric.rb
 test/ruby/test_object.rb
-# test/ruby/test_objectspace.rb             XXXX failures
-# test/ruby/test_optimization.rb            XXXXX hard crash
+test/ruby/test_objectspace.rb
+test/ruby/test_optimization.rb
 test/ruby/test_pack.rb
 test/ruby/test_parse.rb
 test/ruby/test_path.rb
@@ -98,7 +98,7 @@ test/ruby/test_require.rb
 # test/ruby/test_rubyoptions.rb         XXXX failures and crashes
 # test/ruby/test_rubyvm_mjit.rb         XXXXX query
 test/ruby/test_rubyvm.rb
-# test/ruby/test_settracefunc.rb        XXXX failures
+test/ruby/test_settracefunc.rb
 test/ruby/test_signal.rb
 test/ruby/test_sleep.rb
 test/ruby/test_sprintf_comb.rb


### PR DESCRIPTION
Expose the `MMTK::enumerate_object` method for implementing heap traversal.  That allows the Ruby VM to enable ObjectSpace.each_object and TracePoint.  The test case whitelist is also updated to not exclude related test cases so that mmtk-core binding tests will use those test cases.

Related PR: https://github.com/mmtk/ruby/pull/91