### PR TITLE
Handle no-free strings properly.

### DIFF
--- a/.github/scripts/ci-build.sh
+++ b/.github/scripts/ci-build.sh
@@ -31,17 +31,27 @@ pushd $RUBY_PATH
 
     case $DEBUG_LEVEL in
         debug)
-            ../configure --with-mmtk-ruby=$BINDING_PATH --with-mmtk-ruby-debug --prefix=$RUBY_INSTALL_PATH --disable-install-doc cppflags='-g3 -O0 -DRUBY_DEBUG=1 -DRUBY_DEVEL -DUSE_RUBY_DEBUG_LOG=1'
+            ../configure \
+                --with-mmtk-ruby=$BINDING_PATH \
+                --with-mmtk-ruby-debug \
+                --prefix=$RUBY_INSTALL_PATH \
+                --disable-install-doc \
+                cppflags='-g3 -O0 -DRUBY_DEBUG=1 -DRUBY_DEVEL -DUSE_RUBY_DEBUG_LOG=1 -DMMTK_WB_ASSERT_VO'
             make miniruby -j $CI_JOBS
             ;;
 
         release)
-            ../configure --with-mmtk-ruby=$BINDING_PATH --prefix=$RUBY_INSTALL_PATH --disable-install-doc cppflags='-g3'
+            ../configure \
+                --with-mmtk-ruby=$BINDING_PATH \
+                --prefix=$RUBY_INSTALL_PATH \
+                --disable-install-doc cppflags='-g3 -DMMTK_WB_ASSERT_VO'
             make install -j $CI_JOBS
             ;;
 
         vanilla)
-            ../configure --prefix=$RUBY_INSTALL_PATH --disable-install-doc cppflags='-g3'
+            ../configure \
+                --prefix=$RUBY_INSTALL_PATH \
+                --disable-install-doc cppflags='-g3'
             make install -j $CI_JOBS
             ;;
         *)

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -123,14 +123,14 @@ checksum = "0cc8b54b395f2fcfbb3d90c47b01c7f444d94d05bdeb775811dec868ac3bbc26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "cc"
-version = "1.1.13"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
  "jobserver",
  "libc",
@@ -219,7 +219,7 @@ checksum = "4e018fccbeeb50ff26562ece792ed06659b9c2dae79ece77c4456bb10d9bf79b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -251,7 +251,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -394,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.19"
+version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc53a7799a7496ebc9fd29f31f7df80e83c9bda5299768af5f9e59eeea74647"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
 dependencies = [
  "cc",
  "libc",
@@ -438,7 +438,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.27.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=45cdf31055b1b6a629bdb8032adaa6dd5a8e32b9#45cdf31055b1b6a629bdb8032adaa6dd5a8e32b9"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=73be50d1fce1c2f6559ffbc5b7a04623ba62e6c4#73be50d1fce1c2f6559ffbc5b7a04623ba62e6c4"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -474,12 +474,12 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.27.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=45cdf31055b1b6a629bdb8032adaa6dd5a8e32b9#45cdf31055b1b6a629bdb8032adaa6dd5a8e32b9"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=73be50d1fce1c2f6559ffbc5b7a04623ba62e6c4#73be50d1fce1c2f6559ffbc5b7a04623ba62e6c4"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -589,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -647,9 +647,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
@@ -709,7 +709,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -724,9 +724,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.75"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -771,15 +771,15 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # Metadata for the Ruby repository
 [package.metadata.ci-repos.ruby]
 repo = "mmtk/ruby" # This is used by actions/checkout, so the format is "owner/repo", not URL.
-rev = "cd5e3561b6d564a9e5e70a12703873aa8a5f8252"
+rev = "f38ff7179b58479b2f9cdddbfdaf457cd1521bfc"
 
 [lib]
 name = "mmtk_ruby"
@@ -37,7 +37,7 @@ features = ["is_mmtk_object", "object_pinning", "sticky_immix_non_moving_nursery
 
 # Uncomment the following lines to use mmtk-core from the official repository.
 git = "https://github.com/mmtk/mmtk-core.git"
-rev = "45cdf31055b1b6a629bdb8032adaa6dd5a8e32b9"
+rev = "73be50d1fce1c2f6559ffbc5b7a04623ba62e6c4"
 
 # Uncomment the following line to use mmtk-core from a local repository.
 #path = "../../mmtk-core"


### PR DESCRIPTION
This PR updates the `ruby` repo to include commits related to handling Strings with the `STR_NOFREE` flag.

The `ruby` repo also includes a change that forwards `rb_str_tmp_frozen_no_embed_acquire` to `rb_str_tmp_frozen_acquire` because we don't need to workaround page locking when using MMTk.

We also apply `-DMMTK_WB_ASSERT_VO` when running CI tests.  That will help us detect "destination is not MMTk object" bugs earlier at the time when the field is written to.
