### PR TITLE
Hidden field access and debugging features

### DIFF
--- a/.github/scripts/ci-build.sh
+++ b/.github/scripts/ci-build.sh
@@ -10,7 +10,7 @@ pushd $BINDING_PATH
             cargo build
             ;;
         release)
-            cargo build --release
+            cargo build --features extra_assert --release
             ;;
         vanilla)
             echo "Skipped for vanilla build"

--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -376,9 +376,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libgit2-sys"
@@ -437,8 +437,8 @@ dependencies = [
 
 [[package]]
 name = "mmtk"
-version = "0.27.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=73be50d1fce1c2f6559ffbc5b7a04623ba62e6c4#73be50d1fce1c2f6559ffbc5b7a04623ba62e6c4"
+version = "0.28.0"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=c4fdce02274a4b3fee49318cce9f6bf3eb378ae0#c4fdce02274a4b3fee49318cce9f6bf3eb378ae0"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -473,8 +473,8 @@ dependencies = [
 
 [[package]]
 name = "mmtk-macros"
-version = "0.27.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=73be50d1fce1c2f6559ffbc5b7a04623ba62e6c4#73be50d1fce1c2f6559ffbc5b7a04623ba62e6c4"
+version = "0.28.0"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=c4fdce02274a4b3fee49318cce9f6bf3eb378ae0#c4fdce02274a4b3fee49318cce9f6bf3eb378ae0"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -538,15 +538,15 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "portable-atomic"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+checksum = "d30538d42559de6b034bc76fd6dd4c38961b1ee5c6c56e3808c50128fdbc22ce"
 
 [[package]]
 name = "probe"

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -37,7 +37,7 @@ features = ["is_mmtk_object", "object_pinning", "sticky_immix_non_moving_nursery
 
 # Uncomment the following lines to use mmtk-core from the official repository.
 git = "https://github.com/mmtk/mmtk-core.git"
-rev = "73be50d1fce1c2f6559ffbc5b7a04623ba62e6c4"
+rev = "c4fdce02274a4b3fee49318cce9f6bf3eb378ae0"
 
 # Uncomment the following line to use mmtk-core from a local repository.
 #path = "../../mmtk-core"
@@ -47,3 +47,9 @@ default = []
 
 # When moving an object, clear its original copy.
 clear_old_copy = []
+
+# Enable extra assertions in release build.  For debugging.
+extra_assert = []
+
+# Force Immix-based plans to move as many objects as possible.  For debugging.
+immix_stress_copying = ["mmtk/immix_stress_copying"]

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # Metadata for the Ruby repository
 [package.metadata.ci-repos.ruby]
 repo = "mmtk/ruby" # This is used by actions/checkout, so the format is "owner/repo", not URL.
-rev = "f38ff7179b58479b2f9cdddbfdaf457cd1521bfc"
+rev = "c300b86a5260508a46348bd5d3a023a8271c6487"
 
 [lib]
 name = "mmtk_ruby"

--- a/mmtk/cbindgen.toml
+++ b/mmtk/cbindgen.toml
@@ -24,6 +24,9 @@ typedef void* MMTk_NullableObjectReference;
 typedef uint32_t MMTk_AllocationSemantics;
 """
 
+[export]
+include = ["HiddenHeader"]
+
 [export.rename]
 "MMTKBuilder" = "MMTk_Builder"
 "RubyMutator" = "MMTk_Mutator"
@@ -42,3 +45,6 @@ typedef uint32_t MMTk_AllocationSemantics;
 "GC_THREAD_KIND_WORKER" = "MMTK_GC_THREAD_KIND_WORKER"
 "OBJREF_OFFSET" = "MMTK_OBJREF_OFFSET"
 "MIN_OBJ_ALIGN" = "MMTK_MIN_OBJ_ALIGN"
+"HiddenHeader" = "MMTk_HiddenHeader"
+"HAS_MOVED_GIVTBL" = "MMTK_HAS_MOVED_GIVTBL"
+"HIDDEN_SIZE_MASK" = "MMTK_HIDDEN_SIZE_MASK"

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -12,6 +12,7 @@ use std::thread::ThreadId;
 
 use abi::RubyUpcalls;
 use binding::{RubyBinding, RubyBindingFast, RubyBindingFastMut};
+use mmtk::util::Address;
 use mmtk::vm::slot::{SimpleSlot, UnimplementedMemorySlice};
 use mmtk::vm::VMBinding;
 use mmtk::MMTK;
@@ -132,4 +133,21 @@ pub(crate) fn set_panic_hook() {
             old_hook(panic_info);
         }
     }));
+}
+
+/// This kind of assertion is enabled if either building in debug mode or the
+/// "extra_assert" feature is enabled.
+#[macro_export]
+macro_rules! extra_assert {
+    ($($arg:tt)*) => {
+        if std::cfg!(any(debug_assertions, feature = "extra_assert")) {
+            std::assert!($($arg)*);
+        }
+    };
+}
+
+pub(crate) fn is_mmtk_object_safe(addr: Address) -> bool {
+    !addr.is_zero()
+        && addr.is_aligned_to(mmtk::util::is_mmtk_object::VO_BIT_REGION_SIZE)
+        && mmtk::memory_manager::is_mmtk_object(addr).is_some()
 }

--- a/mmtk/src/weak_proc.rs
+++ b/mmtk/src/weak_proc.rs
@@ -9,7 +9,7 @@ use mmtk::{
 use crate::{
     abi::{st_table, GCThreadTLS, RubyObjectAccess},
     binding::MovedGIVTblEntry,
-    upcalls,
+    extra_assert, is_mmtk_object_safe, upcalls,
     utils::AfterAll,
     Ruby,
 };
@@ -228,8 +228,8 @@ trait GlobalTableProcessingWork {
         // `hash_foreach_replace` depends on `gb_object_moved_p` which has to have the semantics
         // of `trace_object` due to the way it is used in `UPDATE_IF_MOVED`.
         let forward_object = |_worker, object: ObjectReference, _pin| {
-            debug_assert!(
-                mmtk::memory_manager::is_mmtk_object(object.to_raw_address()).is_some(),
+            extra_assert!(
+                is_mmtk_object_safe(object.to_raw_address()),
                 "{} is not an MMTk object",
                 object
             );


### PR DESCRIPTION
The main part of this PR is fixing a bug when accessing the hidden field.  Previously, when loading the payload size from the hidden field before the object, it didn't mask out the `HAS_MOVED_GIVTBL` flag, resulting in wrong object sizes.  This PR fixes that.  In both `mmtk-ruby` and `ruby` repos, we encapsulate the access to the hidden field in dedicated functions and make sure the bit masks are applied.

In the `ruby` repo, we also disable the code paths that result in re-embedding "heap" arrays and strings, because that is a source of dangling pointer bugs.

In the `mmtk-ruby` repo, we introduced the `extra_assert!` macro which can be enabled by the "extra_assert" Cargo feature even in release builds.  We also introduced a feature for stressing Immix collectors and a safer `is_mmtk_object_safe` function.