### PR TITLE
Update mmtk and ruby repo revision

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -478,7 +478,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.30.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=374ec2c3bc410422c4ed7250f41a4c6b3ef36223#374ec2c3bc410422c4ed7250f41a4c6b3ef36223"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=302f6110fcf5e0a9787a9c0a01fa07969c30fcf9#302f6110fcf5e0a9787a9c0a01fa07969c30fcf9"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.30.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=374ec2c3bc410422c4ed7250f41a4c6b3ef36223#374ec2c3bc410422c4ed7250f41a4c6b3ef36223"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=302f6110fcf5e0a9787a9c0a01fa07969c30fcf9#302f6110fcf5e0a9787a9c0a01fa07969c30fcf9"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -568,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.1"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "percent-encoding"

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # Metadata for the Ruby repository
 [package.metadata.ci-repos.ruby]
 repo = "mmtk/ruby" # This is used by actions/checkout, so the format is "owner/repo", not URL.
-rev = "f96c2c892673c186e5d132b16478c0a0a22994a8"
+rev = "3688c6ae5f863a0ad3193c9101811fb11c08bded"
 
 [lib]
 name = "mmtk_ruby"
@@ -37,7 +37,7 @@ features = ["is_mmtk_object", "object_pinning", "sticky_immix_non_moving_nursery
 
 # Uncomment the following lines to use mmtk-core from the official repository.
 git = "https://github.com/mmtk/mmtk-core.git"
-rev = "374ec2c3bc410422c4ed7250f41a4c6b3ef36223"
+rev = "302f6110fcf5e0a9787a9c0a01fa07969c30fcf9"
 
 # Uncomment the following line to use mmtk-core from a local repository.
 #path = "../../mmtk-core"

--- a/mmtk/src/binding.rs
+++ b/mmtk/src/binding.rs
@@ -28,9 +28,7 @@ impl Default for RubyBindingFast {
 impl RubyBindingFast {
     pub const fn new() -> Self {
         Self {
-            // Mimic the old behavior when the gc_enabled flag was in mmtk-core.
-            // We may refactor it so that it is false by default.
-            gc_enabled: AtomicBool::new(true),
+            gc_enabled: AtomicBool::new(false),
         }
     }
 }


### PR DESCRIPTION
The mmtk-ruby repo also disables GC on start-up.