### PR TITLE
Multi-Ractor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,8 +269,6 @@ We excluded some tests when testing against MMTk.  Those test cases are listed
 in `test/.excludes-mmtk` in the [`mmtk/ruby`](https://github.com/mmtk/ruby.git)
 repository.
 
--   Test cases that involve Ractors are excluded because it is currently not a
-    priority to support Ractors.
 -   Test cases that involve YJIT are excluded because we have not started
     working on YJIT support, yet.
 -   Some tests involve implementation details of CRuby's default GC, such as

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # Metadata for the Ruby repository
 [package.metadata.ci-repos.ruby]
 repo = "mmtk/ruby" # This is used by actions/checkout, so the format is "owner/repo", not URL.
-rev = "4cb1adabe03bf5ce2d83d99759aa6f7e528d22d5"
+rev = "23e902d75497c0166eb6442b6f5fbabc7a302dc4"
 
 [lib]
 name = "mmtk_ruby"


### PR DESCRIPTION
We enabled multi-Ractor support in the `ruby` repo.

Edited the README.md because we no longer exclude Ractor-related tests.