### PR TITLE
Remove the immix_stress_copying feature.

### DIFF
--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -50,6 +50,3 @@ clear_old_copy = []
 
 # Enable extra assertions in release build.  For debugging.
 extra_assert = []
-
-# Force Immix-based plans to move as many objects as possible.  For debugging.
-immix_stress_copying = ["mmtk/immix_stress_copying"]


### PR DESCRIPTION
The feature of the same name has been removed in mmtk-core.

See: https://github.com/mmtk/mmtk-core/pull/1324