### PR TITLE
unsafe attribute and api.rs

### DIFF
--- a/mmtk/src/abi.rs
+++ b/mmtk/src/abi.rs
@@ -252,7 +252,7 @@ impl GCThreadTLS {
     /// Has undefined behavior if `ptr` is invalid.
     pub unsafe fn check_cast(ptr: *mut GCThreadTLS) -> &'static mut GCThreadTLS {
         assert!(!ptr.is_null());
-        let result = &mut *ptr;
+        let result = unsafe { &mut *ptr };
         debug_assert!({
             let kind = result.kind;
             kind == GC_THREAD_KIND_WORKER
@@ -267,7 +267,7 @@ impl GCThreadTLS {
     /// Has undefined behavior if `ptr` is invalid.
     pub unsafe fn from_vwt_check(vwt: VMWorkerThread) -> &'static mut GCThreadTLS {
         let ptr = Self::from_vwt(vwt);
-        Self::check_cast(ptr)
+        unsafe { Self::check_cast(ptr) }
     }
 
     #[allow(clippy::not_unsafe_ptr_arg_deref)] // `transmute` does not dereference pointer
@@ -283,7 +283,7 @@ impl GCThreadTLS {
     /// Has undefined behavior if the pointer held in C-level TLS is invalid.
     pub unsafe fn from_upcall_check() -> &'static mut GCThreadTLS {
         let ptr = (upcalls().get_gc_thread_tls)();
-        Self::check_cast(ptr)
+        unsafe { Self::check_cast(ptr) }
     }
 
     pub fn worker<'w>(&mut self) -> &'w mut GCWorker<Ruby> {
@@ -314,7 +314,7 @@ impl RawVecOfObjRef {
     ///
     /// This function turns raw pointer into a Vec without check.
     pub unsafe fn into_vec(self) -> Vec<ObjectReference> {
-        Vec::from_raw_parts(self.ptr, self.len, self.capa)
+        unsafe { Vec::from_raw_parts(self.ptr, self.len, self.capa) }
     }
 }
 

--- a/mmtk/src/lib.rs
+++ b/mmtk/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(unsafe_op_in_unsafe_fn)]
+
 extern crate libc;
 extern crate mmtk;
 #[macro_use]


### PR DESCRIPTION
Clippy gives teh `not_unsafe_ptr_arg_deref` lint warning if a function dereferences a raw pointer but is not labelled as `unsafe`.  We used to suppress this warning was because labelling a function `unsafe` automatically grants it rights to use any unsafe operation inside the function.  I deemed that a greater danger because we then won't be able to identify real unsafe sections within an `unsafe` function.

We now set `#![warn(unsafe_op_in_unsafe_fn)]` for the whole lib.  It makes it necessary to use the `unsafe { ... }` block even within `unsafe` functions.  We now explicitly label functions as `unsafe` if they deference raw pointers.  But we set
`#![allow(clippy::missing_safety_doc)]` on the `api.rs` module because the reason for functions to be unsafe in that module is clearly because they are used by C with raw pointers.