### PR TITLE
Update mmtk and ruby repo revision

### DIFF
--- a/mmtk/Cargo.lock
+++ b/mmtk/Cargo.lock
@@ -485,7 +485,7 @@ dependencies = [
 [[package]]
 name = "mmtk"
 version = "0.31.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=efe7b41785eeb07473cbadc93b58d4e1e532353d#efe7b41785eeb07473cbadc93b58d4e1e532353d"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=6ac4f73e21e0b08b2de1d456175ae7caaaf886fd#6ac4f73e21e0b08b2de1d456175ae7caaaf886fd"
 dependencies = [
  "atomic",
  "atomic-traits",
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "mmtk-macros"
 version = "0.31.0"
-source = "git+https://github.com/mmtk/mmtk-core.git?rev=efe7b41785eeb07473cbadc93b58d4e1e532353d#efe7b41785eeb07473cbadc93b58d4e1e532353d"
+source = "git+https://github.com/mmtk/mmtk-core.git?rev=6ac4f73e21e0b08b2de1d456175ae7caaaf886fd#6ac4f73e21e0b08b2de1d456175ae7caaaf886fd"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/mmtk/Cargo.toml
+++ b/mmtk/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # Metadata for the Ruby repository
 [package.metadata.ci-repos.ruby]
 repo = "mmtk/ruby" # This is used by actions/checkout, so the format is "owner/repo", not URL.
-rev = "3051b4d4f3808e7301351e0fc9621cd162d8e0b3"
+rev = "a11526830e747dc68f250a38bbebf01c02bf6462"
 
 [lib]
 name = "mmtk_ruby"
@@ -37,7 +37,7 @@ features = ["is_mmtk_object", "object_pinning", "sticky_immix_non_moving_nursery
 
 # Uncomment the following lines to use mmtk-core from the official repository.
 git = "https://github.com/mmtk/mmtk-core.git"
-rev = "efe7b41785eeb07473cbadc93b58d4e1e532353d"
+rev = "6ac4f73e21e0b08b2de1d456175ae7caaaf886fd"
 
 # Uncomment the following line to use mmtk-core from a local repository.
 #path = "../../mmtk-core"


### PR DESCRIPTION
The `ruby` repository is merged with the master branch.  Notable changes in the `ruby` repository include:

-   The changes for supporting parallel GC in YJIT has been merged
    upstream.
-   The upstream removed some unused functions related to CC table
    marking.
-   The fstring table is now backed by a concurrent set.